### PR TITLE
Fix incorrectly handled parameters in RenderUtil#enableUnscaledScissor

### DIFF
--- a/common/src/main/java/io/github/kabanfriends/craftgr/overlay/widget/impl/ScrollingText.java
+++ b/common/src/main/java/io/github/kabanfriends/craftgr/overlay/widget/impl/ScrollingText.java
@@ -91,7 +91,7 @@ public class ScrollingText extends UIWidget {
         poseStack.pushPose();
         poseStack.scale(2, 2, 2);
         poseStack.translate(x % 2 / 2f, y % 2 / 2f, 0); // Cancel out int rounding difference
-        RenderUtil.enableUnscaledScissor(graphics, scissorX, scissorY, scissorX + scissorW, scissorY + scissorH);
+        RenderUtil.enableUnscaledScissor(graphics, scissorX, scissorY, scissorW, scissorH);
         // Uncomment to debug
         //RenderUtil.fill(poseStack, 0, 0, CraftGR.getInstance().getMinecraft().getWindow().getWidth(), CraftGR.getInstance().getMinecraft().getWindow().getHeight(), 0x8F00FF00);
 

--- a/common/src/main/java/io/github/kabanfriends/craftgr/util/render/RenderUtil.java
+++ b/common/src/main/java/io/github/kabanfriends/craftgr/util/render/RenderUtil.java
@@ -60,6 +60,6 @@ public class RenderUtil {
     }
 
     public static void enableUnscaledScissor(GuiGraphics graphics, int x, int y, int width, int height) {
-        graphics.applyScissor(graphics.scissorStack.push(new UnscaledScreenRectangle(x, y, width - x, height -y)));
+        graphics.applyScissor(graphics.scissorStack.push(new UnscaledScreenRectangle(x, y, width, height)));
     }
 }


### PR DESCRIPTION
enableUnscaledScissor now correctly takes width & height for parameters instead of max X & max Y